### PR TITLE
feat: ajouter Prettier, rééquilibrer le début de jeu et implémenter l…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ function AppContent() {
             <CodeSeller />
             <POShop />
           </div>
-          {game.totalMoneyAccumulated >= 25 && (
+          {game.totalMoneyAccumulated >= 5 && (
             <div className={styles.column}>
               <UpgradeShop />
             </div>

--- a/src/Components/UpgradeShop/UpgradeShop.tsx
+++ b/src/Components/UpgradeShop/UpgradeShop.tsx
@@ -13,10 +13,14 @@ export const UpgradeShop = () => {
     () =>
       _.chain(Upgrade)
         .filter((upgrade) => game.boughtUpgrade[upgrade] === false)
+        .filter((upgrade) => {
+          const minCodeLines = UpgradeInfos[upgrade].minCodeLines;
+          return !minCodeLines || game.totalCodeLinesAccumulated >= minCodeLines;
+        })
         .sortBy((upgrade) => UpgradeInfos[upgrade].price)
         .take(3)
         .value(),
-    [game.boughtUpgrade],
+    [game.boughtUpgrade, game.totalCodeLinesAccumulated],
   );
 
   return (

--- a/src/Game/Game.tsx
+++ b/src/Game/Game.tsx
@@ -222,8 +222,11 @@ export const Game = ({ children }: React.PropsWithChildren) => {
           case Upgrade['5G']:
             setManualSellingForce((prevState) => prevState * 5);
             break;
+          case Upgrade.Prettier:
+            setCodePrice((prevState) => prevState * 1.5);
+            break;
           case Upgrade.Linter:
-            setCodePrice((prevState) => prevState * 1.25);
+            setCodePrice((prevState) => prevState * 2);
             break;
           case Upgrade.CofeeMachine:
             updateDevTeam((_dev, devInfo) => ({

--- a/src/Game/ItemInfo.ts
+++ b/src/Game/ItemInfo.ts
@@ -2,6 +2,7 @@ export type ItemInfo = {
   price: number;
   name: string;
   description: string;
+  minCodeLines?: number; // Nombre minimum de lignes produites pour débloquer
 };
 
 export type ProductionItemInfo = ItemInfo & {

--- a/src/Game/Upgrade.ts
+++ b/src/Game/Upgrade.ts
@@ -16,6 +16,7 @@ export enum Upgrade {
   '5G' = '5G',
 
   // Vente plus chère
+  Prettier = 'Prettier',
   Linter = 'Linter',
 
   // Analytics
@@ -80,15 +81,21 @@ export const UpgradeInfos: Record<Upgrade, ItemInfo> = {
   },
 
   // Selling Price
+  [Upgrade.Prettier]: {
+    price: 25,
+    name: 'Prettier',
+    description: 'Formattez automatiquement votre code pour le vendre 50% plus cher !',
+  },
   [Upgrade.Linter]: {
-    price: 400,
+    price: 100,
     name: 'Linter',
-    description: 'Vous utilisez un linter, rendant votre code plus beau et permettant de le vendre à un meilleur prix !',
+    description: 'Vous utilisez un linter, rendant votre code plus beau et permettant de le vendre deux fois plus cher !',
+    minCodeLines: 500,
   },
 
   // Analytics
   [Upgrade.SpeedCounter]: {
-    price: 60,
+    price: 30,
     name: 'Compteur de vitesse',
     description: 'Affiche votre vitesse de frappe en temps réel pour optimiser votre productivité !',
   },

--- a/src/assets/code.txt
+++ b/src/assets/code.txt
@@ -223,8 +223,11 @@ export const Game = ({ children }: React.PropsWithChildren) => {
           case Upgrade['5G']:
             setManualSellingForce((prevState) => prevState * 5);
             break;
+          case Upgrade.Prettier:
+            setCodePrice((prevState) => prevState * 1.5);
+            break;
           case Upgrade.Linter:
-            setCodePrice((prevState) => prevState * 1.25);
+            setCodePrice((prevState) => prevState * 2);
             break;
           case Upgrade.CofeeMachine:
             updateDevTeam((_dev, devInfo) => ({


### PR DESCRIPTION
…e déblocage par lignes

- Ajouter l'upgrade Prettier (25€, x1.5 sur prix du code)
- Modifier Linter : 25€ → 100€, débloqué à 500 lignes produites
- Baisser compteur de vitesse : 60€ → 30€
- Afficher shop upgrades dès 5€ accumulés (au lieu de 25€)
- Implémenter système de déblocage par lignes (minCodeLines dans ItemInfo)
- Améliorer progression early-game