### PR TITLE
fix: afficher les boutons d'upgrade côte à côte avec largeur égale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,3 +286,4 @@ Voir `doc/Roadmap.md` pour la roadmap de développement actuelle. Les fonctionna
 - Mécaniques de démission des employés
 
 - n'essaie pas de lancer le serveur avec npm run dev, je m'occupe de lancer et tester le jeu
+- quand tu changes de branche, penses à faire un pull derrière pour être à jour sur la branche

--- a/src/Components/UpgradeShop/UpgradeShop.module.scss
+++ b/src/Components/UpgradeShop/UpgradeShop.module.scss
@@ -4,4 +4,9 @@
   display: flex;
   gap: $spacing-xs;
   padding: $spacing-md;
+
+  > * {
+    flex: 1;
+    min-width: 0; // Permet au contenu de shrink si nécessaire
+  }
 }


### PR DESCRIPTION
Ajoute flex: 1 aux enfants directs de .upgradeList pour répartir équitablement l'espace entre les 3 boutons d'upgrade