### PR TITLE
fix: colonnes du jeu prennent chacune 1/3 de la largeur

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -57,10 +57,12 @@
 
 .gameLayout {
   display: flex;
+  gap: $spacing-md;
 }
 
 .column {
   display: flex;
   flex-direction: column;
-  width: $column-width;
+  flex: 1;
+  min-width: 0; // Permet au contenu de shrink si nécessaire
 }


### PR DESCRIPTION
Remplace width fixe par flex: 1 pour répartir équitablement l'espace entre les 3 colonnes (Artisanat, Vente, Upgrades)